### PR TITLE
Update traefik to 3.0

### DIFF
--- a/_base/compose/docker-compose.yml
+++ b/_base/compose/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   traefik:
-    image: traefik:v2.5.3
+    image: traefik:v3.0
     env_file:
       - .env
     networks:


### PR DESCRIPTION
This PR updates traefik to 3.0. Curerntly used version had error that would sometimes silently fail all incoming requests making node inavailable. After updating this issue seems to go away.