### PR TITLE
Added needed enviroment variables for databases to show on panel

### DIFF
--- a/panel/compose/docker-compose.yml
+++ b/panel/compose/docker-compose.yml
@@ -9,6 +9,8 @@ x-common:
   panel:
     &panel-environment
     APP_URL: "https://panel.example.com"
+    HASHIDS_SALT: "CHANGE_ME" # 20 character length string, you can use this command: openssl rand -base64 20
+    HASHIDS_LENGTH: 8
     # A list of valid timezones can be found here: http://php.net/manual/en/timezones.php
     APP_TIMEZONE: "UTC"
     APP_SERVICE_AUTHOR: "admin@example.com"


### PR DESCRIPTION
This pull request fixes the 500 error shown when visiting /api/client/servers/<id>/databases?include=password endpoint
`An Unexpected error was encountered while processing this request, please try again.`

As said by someone over the Pterodactyl Discord: 

> You now need to specify the salt and length in the compose file.
> 
> As generated by the non-dockerized version of the panel, HASHIDS_SALT is a randomly generated 20 digit string with numbers and symbols. HASHIDS_LENGTH is the number 8