### PR TITLE
Feat: added network name for docker provider in traefik

### DIFF
--- a/_base/data/traefik/traefik.toml
+++ b/_base/data/traefik/traefik.toml
@@ -10,6 +10,7 @@
     address = ":443"
 
 [providers.docker]
+  network="pterodactyl"
 
 [certificatesResolvers.letsencrypt.acme]
   email = "admin@example.com"


### PR DESCRIPTION
This MR does the following:

- Adds `pterodactyl` network for traefik under providers docker configuration of treafik.

For more info:  [traefik-providers-docker-network](https://doc.traefik.io/traefik/providers/docker/#network)

This should resolve  Timeout at Gateway 404 in fresh docker compose installs.
